### PR TITLE
fix(omaha): Oem to OEM

### DIFF
--- a/omaha/omaha.go
+++ b/omaha/omaha.go
@@ -86,7 +86,7 @@ type App struct {
 	// coreos update engine extensions
 	BootId         string `xml:"bootid,attr,omitempty"`
 	PreviousBootId string `xml:"previousbootid,attr,omitempty"`
-	Oem            string `xml:"oem,attr,omitempty"`
+	OEM            string `xml:"oem,attr,omitempty"`
 }
 
 func NewApp(id string) *App {


### PR DESCRIPTION
Be consistent with the Go style guide and make the acronym fully uppercase.
