### PR TITLE
fix(omaha): fixup Oem test after change

### DIFF
--- a/omaha/omaha_test.go
+++ b/omaha/omaha_test.go
@@ -36,7 +36,7 @@ func TestOmahaRequestUpdateCheck(t *testing.T) {
 		t.Error("Expected a Previous Boot Id")
 	}
 
-	if v.Apps[0].Oem != "ec3000" {
+	if v.Apps[0].OEM != "ec3000" {
 		t.Error("Expected an OEM")
 	}
 


### PR DESCRIPTION
I forgot to run the tests after making the change to OEM. Fix.
