### PR TITLE
protocol: add ParseRequest and ParseResponse functions

### DIFF
--- a/omaha/parse.go
+++ b/omaha/parse.go
@@ -1,0 +1,71 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omaha
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"mime"
+	"strings"
+)
+
+// checkContentType verifies the HTTP Content-Type header properly
+// declares the document is XML and UTF-8. Blank is assumed OK.
+func checkContentType(contentType string) error {
+	if contentType == "" {
+		return nil
+	}
+
+	mType, mParams, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return err
+	}
+
+	if mType != "text/xml" && mType != "application/xml" {
+		return fmt.Errorf("unsupported content type %q", mType)
+	}
+
+	charset, _ := mParams["charset"]
+	if charset != "" && strings.ToLower(charset) != "utf-8" {
+		return fmt.Errorf("unsupported content charset %q", charset)
+	}
+
+	return nil
+}
+
+// parseReqOrResp parses Request and Response objects.
+func parseReqOrResp(r io.Reader, v interface{}) error {
+	decoder := xml.NewDecoder(r)
+	if err := decoder.Decode(v); err != nil {
+		return err
+	}
+
+	var protocol string
+	switch v := v.(type) {
+	case *Request:
+		protocol = v.Protocol
+	case *Response:
+		protocol = v.Protocol
+	default:
+		panic(fmt.Errorf("unexpected type %T", v))
+	}
+
+	if protocol != "3.0" {
+		return fmt.Errorf("unsupported omaha protocol: %q", protocol)
+	}
+
+	return nil
+}

--- a/omaha/parse_test.go
+++ b/omaha/parse_test.go
@@ -1,0 +1,55 @@
+// Copyright 2017 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package omaha
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCheckContentType(t *testing.T) {
+	for _, tt := range []struct {
+		ct string
+		ok bool
+	}{
+		{"", true},
+		{"text/xml", true},
+		{"text/XML", true},
+		{"application/xml", true},
+		{"text/plain", false},
+		{"xml", false},
+		{"text/xml; charset=utf-8", true},
+		{"text/xml; charset=UTF-8", true},
+		{"text/xml; charset=ascii", false},
+	} {
+		err := checkContentType(tt.ct)
+		if tt.ok && err != nil {
+			t.Errorf("%q failed: %v", tt.ct, err)
+		}
+		if !tt.ok && err == nil {
+			t.Errorf("%q was not rejected", tt.ct)
+		}
+	}
+}
+
+func TestParseBadVersion(t *testing.T) {
+	r := strings.NewReader(`<request protocol="2.0"></request>`)
+	err := parseReqOrResp(r, &Request{})
+	if err == nil {
+		t.Error("Bad protocol version was accepted")
+	} else if err.Error() != `unsupported omaha protocol: "2.0"` {
+		t.Errorf("Wrong error: %v", err)
+	}
+}

--- a/omaha/protocol.go
+++ b/omaha/protocol.go
@@ -24,6 +24,7 @@ package omaha
 
 import (
 	"encoding/xml"
+	"io"
 )
 
 // Request sent by the Omaha client
@@ -54,6 +55,22 @@ func NewRequest() *Request {
 			// TODO(marineam): Version and ServicePack
 		},
 	}
+}
+
+// ParseRequest verifies and returns the parsed Request document.
+// The MIME Content-Type header may be provided to sanity check its
+// value; if blank it is assumed to be XML in UTF-8.
+func ParseRequest(contentType string, body io.Reader) (*Request, error) {
+	if err := checkContentType(contentType); err != nil {
+		return nil, err
+	}
+
+	r := &Request{}
+	if err := parseReqOrResp(body, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
 func (r *Request) AddApp(id, version string) *AppRequest {
@@ -136,6 +153,22 @@ func NewResponse() *Response {
 		Server:   "go-omaha",
 		DayStart: DayStart{ElapsedSeconds: "0"},
 	}
+}
+
+// ParseResponse verifies and returns the parsed Response document.
+// The MIME Content-Type header may be provided to sanity check its
+// value; if blank it is assumed to be XML in UTF-8.
+func ParseResponse(contentType string, body io.Reader) (*Response, error) {
+	if err := checkContentType(contentType); err != nil {
+		return nil, err
+	}
+
+	r := &Response{}
+	if err := parseReqOrResp(body, r); err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
 type DayStart struct {


### PR DESCRIPTION
For parsing and verification of of HTTP request and response bodies,
including optional checking the Content-Type field which the handler
previously didn't do.