### PR TITLE
protocol: remove stray Event type

### DIFF
--- a/omaha/protocol.go
+++ b/omaha/protocol.go
@@ -237,14 +237,6 @@ type OS struct {
 	Arch        string `xml:"arch,attr,omitempty"`
 }
 
-type Event struct {
-	Type            EventType   `xml:"eventtype,attr"`
-	Result          EventResult `xml:"eventresult,attr"`
-	PreviousVersion string      `xml:"previousversion,attr,omitempty"`
-	ErrorCode       string      `xml:"errorcode,attr,omitempty"`
-	Status          string      `xml:"status,attr,omitempty"`
-}
-
 type URL struct {
 	CodeBase string `xml:"codebase,attr"`
 }


### PR DESCRIPTION
The Event struct was split into EventRequest and EventResponse back in
75a1125f but the older now unused type was never deleted.