### PR TITLE
update_engine_events.go: Add a custom "InstallStarted" event.

### DIFF
--- a/omaha/client/update_engine_events.go
+++ b/omaha/client/update_engine_events.go
@@ -32,6 +32,10 @@ var (
 		Type:   omaha.EventTypeUpdateDownloadFinished,
 		Result: omaha.EventResultSuccess,
 	}
+	EventInstallStarted = &omaha.EventRequest{
+		Type:   omaha.EventTypeInstallStarted,
+		Result: omaha.EventResultSuccess,
+	}
 	EventInstalled = &omaha.EventRequest{
 		Type:   omaha.EventTypeUpdateComplete,
 		Result: omaha.EventResultSuccess,


### PR DESCRIPTION
This can help us to know how many clusters have clicked "start upgrade",
plus those in automatic mode.